### PR TITLE
Skip malformed interests (presumbly due to banned entries)

### DIFF
--- a/extension/tasks/interest.js
+++ b/extension/tasks/interest.js
@@ -38,6 +38,10 @@ export default class Interest extends Task {
 
     async processInterest(interest, version, type)
     {
+        if (!interest.subject) {
+            console.warn("Encountered malformed interest, skipping");
+            return;
+        }        
         let subjectId = parseInt(interest.subject.id)
         let interestId = parseInt(interest.id);
         let row = await this.storage.interest.get({ subject: subjectId });


### PR DESCRIPTION
修复备份影/音/书/游/剧时遇到空 json 对象（应该是被封禁的条目）会导致所有后续备份失败的问题 #98 #99 #100

已本地测试可行
